### PR TITLE
Moved texture loading out of DoHeader prefix and into a static class

### DIFF
--- a/Source/Assemblies/CompactWorkTab/PawnColumnWorker_WorkPriority_DoHeader.cs
+++ b/Source/Assemblies/CompactWorkTab/PawnColumnWorker_WorkPriority_DoHeader.cs
@@ -9,9 +9,6 @@ namespace CompactWorkTab
     [HarmonyPatch(typeof(PawnColumnWorker_WorkPriority), nameof(PawnColumnWorker_WorkPriority.DoHeader))]
     public class PawnColumnWorker_WorkPriority_DoHeader
     {
-        private static readonly Texture2D SortingIcon = ContentFinder<Texture2D>.Get("UI/Icons/Sorting");
-        private static readonly Texture2D SortingDescendingIcon = ContentFinder<Texture2D>.Get("UI/Icons/SortingDescending");
-
         private static bool Prefix(PawnColumnWorker_WorkPriority __instance, Rect rect, PawnTable table)
         {
             if (!ModSettings.DrawLabelsVertically) return true;
@@ -20,7 +17,7 @@ namespace CompactWorkTab
 
             if (table.SortingBy == __instance.def)
             {
-                Texture2D tex = table.SortingDescending ? SortingDescendingIcon : SortingIcon;
+                Texture2D tex = table.SortingDescending ? Textures.SortingDescendingIcon : Textures.SortingIcon;
                 GUI.DrawTexture(new Rect(rect.xMax - tex.width - 1f, rect.yMax - tex.height - 1f, tex.width, tex.height), tex);
             }
 

--- a/Source/Assemblies/CompactWorkTab/Textures.cs
+++ b/Source/Assemblies/CompactWorkTab/Textures.cs
@@ -1,0 +1,12 @@
+using UnityEngine;
+using Verse;
+
+namespace CompactWorkTab
+{
+    [StaticConstructorOnStartup]
+    public static class Textures
+    {
+        public static readonly Texture2D SortingIcon = ContentFinder<Texture2D>.Get("UI/Icons/Sorting");
+        public static readonly Texture2D SortingDescendingIcon = ContentFinder<Texture2D>.Get("UI/Icons/SortingDescending");
+    }
+}


### PR DESCRIPTION
- Removed local fields SortingIcon and SortingDescendingIcon out of PawnColumnWorker_WorkPriority_DoHeader
- Added them to a static Textures class
- Changed references in PawnColumnWorker_WorkPriority_DoHeader to point to the Texture class instead of the local fields