### PR TITLE
Moved inclined headers to fit over their columns

### DIFF
--- a/Source/Assemblies/CompactWorkTab/LabelDrawer.cs
+++ b/Source/Assemblies/CompactWorkTab/LabelDrawer.cs
@@ -102,7 +102,7 @@ namespace CompactWorkTab
             );
 
             // Calculate the required horizontal offset to make c' match the target position
-            float xOffset = (rect.x + rect.width / 2) - cPrime.x;
+            float xOffset = rect.xMax - cPrime.x;
 
             // Apply the offset to the rotatedRect
             rotatedRect.x += xOffset;


### PR DESCRIPTION
- Calculate the horizontal offset using rect.xMax instead of rect.x + rect.width / 2
- Apply the calculated offset to the rotatedRect for proper positioning
