### PR TITLE
Add Textures to build config

### DIFF
--- a/.github/setup-repo.sh
+++ b/.github/setup-repo.sh
@@ -8,7 +8,7 @@ gh variable set MOD_NAME -b $MOD_NAME
 gh variable set SLN_PATH -b "Source/Assemblies/$MOD_NAME.sln"
 gh variable set CSPROJ_PATH -b "Source/Assemblies/$MOD_NAME/$MOD_NAME.csproj"
 gh variable set ASSEMBLY_PATH -b "1.4/Assemblies/$MOD_NAME.dll"
-gh variable set ZIP_CONTENTS -b "1.4/ About/ CHANGELOG.txt LICENSE"
+gh variable set ZIP_CONTENTS -b "1.4/ About/ Textures/ CHANGELOG.txt LICENSE"
 
 # Pull request type labels
 


### PR DESCRIPTION
- In 1.2.0 the Textures folder was missing. This fixes that.