### PR TITLE
Change branch wildcard from '*' to '**'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - '*'
+      - '**'
 
 jobs:
   ci:


### PR DESCRIPTION
- This should catch all branches, including ones with "/" in their names
